### PR TITLE
fixed --deftraback rgb color codes

### DIFF
--- a/addons/jf-blue.css
+++ b/addons/jf-blue.css
@@ -1,4 +1,4 @@
 :root {
   --accent: #00a4dc;
-  --deftraback: rgb(0 164 220 / 0.2) !important;
+  --deftraback: rgb(0, 164, 220, 0.2) !important;
 }

--- a/addons/jf-purple.css
+++ b/addons/jf-purple.css
@@ -1,4 +1,4 @@
 :root {
   --accent: #aa5cc3;
-  --deftraback: rgb(170 92 195 / 0.2) !important;
+  --deftraback: rgb(170, 92, 195, 0.2) !important;
 }


### PR DESCRIPTION
The RGB color codes where not specified correctly so no mather the chosen color the  --deftrabac always showed red. 

I corrected and tested this 😄 